### PR TITLE
add support for ios

### DIFF
--- a/site/templates/application.jet
+++ b/site/templates/application.jet
@@ -11,6 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <link rel="manifest" href="/manifest.json">
+    <link rel="apple-touch-icon" href="/images/common/shift72-logo-192px.png">
     <link rel="preload" href="/classifications.all.json" as="fetch" crossorigin type="application/json">
 
     <!-- Kibble:{{ version }} -->


### PR DESCRIPTION
Safari iOS doesn't respect the manifest, instead they require a meta tag.

https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html

Adds meta link to app icon.